### PR TITLE
Post retool fixes

### DIFF
--- a/components/GalleryComponents/Gallery/galleryStyles.scss
+++ b/components/GalleryComponents/Gallery/galleryStyles.scss
@@ -309,6 +309,13 @@
         @include media-breakpoint-down(sm) {
             top: -70px;
         }
+
+        span {
+            color: white!important;
+        }
+        em {
+            color: white!important;
+        }
     }
 
     .lightbox-auto {

--- a/components/GalleryComponents/LightBox/LightBox.tsx
+++ b/components/GalleryComponents/LightBox/LightBox.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect } from "react"
 import { Cross } from "../../icons"
-// import { Trans } from "next-i18next"
 import Image from "next/image"
 
 interface LightBoxProps {
@@ -82,9 +81,7 @@ const LightBox = ({ index, setImage, images, lightBox, setLightBox, backupImages
                             alt={images[index]?.alt || images[index].title}
                         />
                     </div>
-                    <h1 dangerouslySetInnerHTML={{ __html: images[index].title ?? backupImages?.[index]?.title }}>
-                        {/* <Trans>{images[index].title}</Trans> */}
-                    </h1>
+                    <h1 dangerouslySetInnerHTML={{ __html: images[index].title ?? backupImages?.[index]?.title }}></h1>
                     <div className="lightbox-auto lightbox-rightArrow">
                         {index + 1 !== images.length && (
                             <span

--- a/components/GalleryComponents/LightBox/LightBox.tsx
+++ b/components/GalleryComponents/LightBox/LightBox.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from "react"
 import { Cross } from "../../icons"
-import { Trans } from "next-i18next"
+// import { Trans } from "next-i18next"
 import Image from "next/image"
 
 interface LightBoxProps {
@@ -11,12 +11,17 @@ interface LightBoxProps {
         title: string
         alt?: string
     }[]
+    backupImages?: {
+        src: string
+        title: string
+        alt?: string
+    }[]
     setGallery: React.Dispatch<React.SetStateAction<boolean>>
     setLightBox: React.Dispatch<React.SetStateAction<boolean>>
     lightBox: boolean
 }
 
-const LightBox = ({ index, setImage, images, lightBox, setLightBox }: LightBoxProps) => {
+const LightBox = ({ index, setImage, images, lightBox, setLightBox, backupImages = [] }: LightBoxProps) => {
     const handleSwitch = useCallback(
         (type: string) => {
             if (type === "inc" && index + 1 !== images.length) {
@@ -77,8 +82,8 @@ const LightBox = ({ index, setImage, images, lightBox, setLightBox }: LightBoxPr
                             alt={images[index]?.alt || images[index].title}
                         />
                     </div>
-                    <h1>
-                        <Trans>{images[index].title}</Trans>
+                    <h1 dangerouslySetInnerHTML={{ __html: images[index].title ?? backupImages?.[index]?.title }}>
+                        {/* <Trans>{images[index].title}</Trans> */}
                     </h1>
                     <div className="lightbox-auto lightbox-rightArrow">
                         {index + 1 !== images.length && (

--- a/components/GalleryComponents/Mosaic/Mosaic.tsx
+++ b/components/GalleryComponents/Mosaic/Mosaic.tsx
@@ -149,6 +149,7 @@ export const Mosaic = ({ images, blocks, uncropped, subTitle }: MosaicProps) => 
                                 index={index}
                                 setImage={setImage}
                                 images={uncropped}
+                                backupImages={images}
                                 lightBox={lightBox}
                                 setLightBox={setLightBox}
                                 setGallery={() => {}}

--- a/components/common/PrayerPoints/PrayerPoints.tsx
+++ b/components/common/PrayerPoints/PrayerPoints.tsx
@@ -74,7 +74,11 @@ export default function PrayerPoints({ topicTrans, displayStyle }: prayerProps) 
                         <Trans t={t} i18nKey="prayerSummary.subtitle" />
                     </Card.Text>
 
-                    <div dangerouslySetInnerHTML={{ __html: prayerPoints }} data-testid={"prayer-points-points"} />
+                    <div
+                        className="bullet-points-wrapper"
+                        dangerouslySetInnerHTML={{ __html: prayerPoints }}
+                        data-testid={"prayer-points-points"}
+                    />
 
                     {buttonPrompts && (
                         <>

--- a/pages/topics/[topicPage].tsx
+++ b/pages/topics/[topicPage].tsx
@@ -13,7 +13,7 @@ import { PhotosWrapper } from "../../components/GalleryComponents/PhotosWrapper/
 import PrayerResponse from "../../components/topic/PrayerResponse/PrayerResponse"
 import { StickyNav, Tab } from "../../components/topic/StickyNav/StickyNav"
 import RelatedContent from "../../components/topic/RelatedContent/RelatedContent"
-import { ReferencesSection } from "../../components/topic/References/References"
+// import { ReferencesSection } from "../../components/topic/References/References"
 import nextI18nextConfig from "../../next-i18next.config"
 
 export const getServerSideProps: GetServerSideProps = async ({ params, locale }: any) => {
@@ -33,31 +33,29 @@ export const getServerSideProps: GetServerSideProps = async ({ params, locale }:
     }
 }
 
-const JsonLink = ({ children = "" }: { children?: string }) => {
-    const url = children
-    const onClick = () => window.open(url, "_blank")
-    return (
-        <a href={url} onClick={onClick}>
-            {url}
-        </a>
-    )
-}
+// const JsonLink = ({ children = "" }: { children?: string }) => {
+//     const url = children
+//     const onClick = () => window.open(url, "_blank")
+//     return (
+//         <a href={url} onClick={onClick}>
+//             {url}
+//         </a>
+//     )
+// }
 
 export default function TopicPage({ localeRef }: { localeRef: string }) {
     const { t } = useTranslation(localeRef)
     const { t: topicCommon } = useTranslation("topic-pages")
 
     // Objects holding translations
-    let textContent = t("textBody", { returnObjects: true }) as string[]
-    textContent = Array.isArray(textContent) ? textContent : []
+    const textContent = t("textBody")
 
-    let textAsterisk = t("textBodyAsterisk", { returnObjects: true }) as string[]
-    textAsterisk = Array.isArray(textAsterisk) ? textAsterisk : []
+    const textAsterisk = t("textBodyAsterisk")
 
     const navTabs: Tab[] = topicCommon("nav", { returnObjects: true }) as Tab[]
 
     const galleryLabel: string = topicCommon("galleryLabel")
-    const factsLabel: string = topicCommon("factsLabel")
+    // const factsLabel: string = topicCommon("factsLabel")
     const galleryClickInstructions: string = topicCommon("galleryClickInstructions")
     const galleryImageText: string = topicCommon("galleryImageText")
     const localeImages: any[] = t("photos", { returnObjects: true }) as any[]
@@ -72,9 +70,9 @@ export default function TopicPage({ localeRef }: { localeRef: string }) {
 
     const quote: string = t("quote.content")
 
-    const infographicDesktop: string = t("infographic.desktop")
-    const infographicTablet: string = t("infographic.tablet")
-    const infographicMobile: string = t("infographic.mobile")
+    // const infographicDesktop: string = t("infographic.desktop")
+    // const infographicTablet: string = t("infographic.tablet")
+    // const infographicMobile: string = t("infographic.mobile")
 
     const previousText: string = topicCommon("previousTopic")
     const nextText: string = topicCommon("nextTopic")
@@ -126,18 +124,12 @@ export default function TopicPage({ localeRef }: { localeRef: string }) {
                     )}
 
                     <Container className="main-content mt-0">
-                        {textContent.map((text: string, idx: number) => (
-                            <p key={idx + text}>
-                                <Trans components={{ url: <JsonLink /> }}> {text} </Trans>
-                            </p>
-                        ))}
+                        <div dangerouslySetInnerHTML={{ __html: textContent }} />
                     </Container>
                     <Container className="fs-5">
-                        {textAsterisk.map((text: string, idx: number) => (
-                            <p key={idx + text}>
-                                <Trans components={{ url: <JsonLink />, sup: <sup /> }}> {text} </Trans>
-                            </p>
-                        ))}
+                        {textAsterisk !== "textBodyAsterisk" && (
+                            <div dangerouslySetInnerHTML={{ __html: textAsterisk }} />
+                        )}
                     </Container>
 
                     {/* Images */}
@@ -159,7 +151,7 @@ export default function TopicPage({ localeRef }: { localeRef: string }) {
 
                     {/* Infographics: Uncomment after conference */}
 
-                    <CollapseBlock title={factsLabel} startOpened={true} galleryType={"infographic"}>
+                    {/* <CollapseBlock title={factsLabel} startOpened={true} galleryType={"infographic"}>
                         <Container className="mt-3 d-flex justify-content-center px-0">
                             <Image className="d-none d-xl-block w-100" src={infographicDesktop} alt="infographic" />
                             <Image
@@ -173,7 +165,7 @@ export default function TopicPage({ localeRef }: { localeRef: string }) {
                     <Container className="">
                         <hr />
                         <ReferencesSection />
-                    </Container>
+                    </Container> */}
                     <Container className={"bottom-spacing"}></Container>
                 </Container>
 

--- a/pages/topics/[topicPage].tsx
+++ b/pages/topics/[topicPage].tsx
@@ -13,7 +13,6 @@ import { PhotosWrapper } from "../../components/GalleryComponents/PhotosWrapper/
 import PrayerResponse from "../../components/topic/PrayerResponse/PrayerResponse"
 import { StickyNav, Tab } from "../../components/topic/StickyNav/StickyNav"
 import RelatedContent from "../../components/topic/RelatedContent/RelatedContent"
-// import { ReferencesSection } from "../../components/topic/References/References"
 import nextI18nextConfig from "../../next-i18next.config"
 
 export const getServerSideProps: GetServerSideProps = async ({ params, locale }: any) => {

--- a/styles/home.scss
+++ b/styles/home.scss
@@ -212,13 +212,15 @@ $home-paragraph-text-mobile: $home-paragraph-text - 2px;
     }
 
     $bullet-point-factor: 1px;
-    .bullet-point {
-        font-size: $home-paragraph-text;
-        @include media-breakpoint-down(xl) {
-            font-size: $home-paragraph-text-tablet;
-        }
-        @include media-breakpoint-down(md) {
-            font-size: $home-paragraph-text-mobile;
+    .bullet-points-wrapper {
+        li {
+            font-size: $home-paragraph-text;
+            @include media-breakpoint-down(xl) {
+                font-size: $home-paragraph-text-tablet;
+            }
+            @include media-breakpoint-down(md) {
+                font-size: $home-paragraph-text-mobile;
+            }
         }
     }
 

--- a/styles/topicPage.scss
+++ b/styles/topicPage.scss
@@ -5,7 +5,7 @@
 // Hero Image Section
 // -------------------------
 
-ul.bullet-points {
+.bullet-points-wrapper {
     margin-bottom: 0px;
 }
 
@@ -20,9 +20,13 @@ ul.bullet-points {
     }
 }
 
-.bullet-point {
-    // match article text size (.main-content)
-    font-size: 1.125rem;
+.bullet-points-wrapper {
+    li {
+        // match article text size (.main-content)
+        font-size: 1.125rem;
+        margin-top: 0.5rem;
+        margin-bottom: 0.5rem;
+    }
 }
 
 .hero-photo {
@@ -90,6 +94,9 @@ ul.bullet-points {
 
 .main-content {
     font-size: 1.125rem;
+    p {
+        font-size: 1.125rem;
+    }
 }
 
 .prev-next-buttons {

--- a/test/components/Common/PrayerPoints/__snapshots__/PrayerPoints.test.tsx.snap
+++ b/test/components/Common/PrayerPoints/__snapshots__/PrayerPoints.test.tsx.snap
@@ -39,6 +39,7 @@ exports[`Prayer Points Snapshot test 1`] = `
               prayerSummary.subtitle
             </p>
             <div
+              class="bullet-points-wrapper"
               data-testid="prayer-points-points"
             >
               A,B
@@ -96,6 +97,7 @@ exports[`Prayer Points Snapshot test 1`] = `
             prayerSummary.subtitle
           </p>
           <div
+            class="bullet-points-wrapper"
             data-testid="prayer-points-points"
           >
             A,B


### PR DESCRIPTION
Couple things I noticed after the transition to retool that were not consistent with the existing site, that are now fixed in this PR:

- Prayer points font sizing and spacing wasn't correct (home page, topic page top and topic page bottom)
- Photo light box captions had html elements shown in them
- Topic body text, and text asterisks text was not appearing
- infographics and references need to be commented out while they are still in development

Please let me know if you find anything else! I think from here it would be safe to deploy this to prod.