### PR TITLE
add global level ja font

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -16,6 +16,10 @@ export default function Document({ __NEXT_DATA__ }) {
                     href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,400;1,500;1,600;1,700;1,800&display=swap"
                     rel="stylesheet"
                 />
+                <link
+                    href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,400;1,500;1,600;1,700;1,800&display=swap"
+                    rel="stylesheet"
+                />
                 <link rel="icon" href="/favicon.ico" />
             </Head>
             <body>

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,8 +1,10 @@
 import { Html, Head, Main, NextScript } from "next/document"
 
-export default function Document() {
+export default function Document({ __NEXT_DATA__ }) {
+    const lang = __NEXT_DATA__.locale || "en"
+
     return (
-        <Html lang="en">
+        <Html lang={lang}>
             <Head>
                 <link rel="preconnect" href="https://fonts.googleapis.com" />
                 <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="true" />

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -17,6 +17,11 @@
 @import "./resources.scss";
 @import "./topicPage.scss";
 
+// Language support
+:lang(ja) {
+    font-family: $font-family-ja !important;
+}
+
 // Misc
 
 .placeholder-image {

--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -54,6 +54,7 @@ $font-sizes: (
 // Adelle / Aleo - heading, quote body
 $font-family-base: "Proxima Nova", "Open Sans", "sans-serif";
 $font-family-secondary: "Aleo", "adelle", "serif";
+$font-family-ja: "Noto Sans JP", "Noto Sans", "Open Sans", "sans-serif";
 
 // From design library, please prefer media-breakpoint-up/down/only/between to target certain breakpoints
 // See also: https://getbootstrap.com/docs/5.2/layout/breakpoints/#media-queries


### PR DESCRIPTION
This should fix a refresh still using 'en' fonts (and is probably the root cause of what Sarah has been noticing with the fonts)
Also adds css for using Noto Sans JP at the main.scss level